### PR TITLE
Fix wrong credentials notification

### DIFF
--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client";
+import { ApolloError, useMutation } from "@apollo/client";
 import { useState, createContext, useContext, useEffect, FC } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -12,6 +12,9 @@ const oneMonthInMS = 2629800000;
 
 export const AuthProvider: FC<AuthProps> = ({ children }) => {
   const [user, setUser] = useState<{ token: string; expiry: number }>();
+  const [loginError, setLoginError] = useState<undefined | ApolloError>(
+    undefined
+  );
 
   const navigate = useNavigate();
   const userData = getUserDataFromStorage("user");
@@ -24,6 +27,11 @@ export const AuthProvider: FC<AuthProps> = ({ children }) => {
   }, []);
 
   const [login, { loading, error }] = useMutation<Login>(LOGIN);
+
+  useEffect(() => {
+    const isError = !!error;
+    isError ? setLoginError(error) : setLoginError(undefined);
+  }, [error]);
 
   const signin = (email: string, password: string, checked: boolean) => {
     login({
@@ -48,7 +56,7 @@ export const AuthProvider: FC<AuthProps> = ({ children }) => {
       });
   };
 
-  const value = { user, signin, error, loading };
+  const value = { user, signin, loginError, loading, setLoginError };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/auth/interface.ts
+++ b/src/auth/interface.ts
@@ -5,7 +5,9 @@ export interface AuthContextType {
   user?: UserTokenWithExpiry;
   signin: (email: string, password: string, checked: boolean) => void;
   error?: ApolloError;
+  loginError?: ApolloError;
   loading?: boolean;
+  setLoginError: (error: any) => void;
 }
 
 export interface AuthProps {

--- a/src/components/pages/LoginPage/index.tsx
+++ b/src/components/pages/LoginPage/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useLayoutEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Form, Field } from "react-final-form";
 import { Navigate } from "react-router-dom";
@@ -7,14 +7,18 @@ import useAuth from "../../../auth/AuthProvider";
 import Button from "../../atoms/Button";
 import Checkbox from "../../atoms/Checkbox";
 import ErrorMessage from "../../atoms/ErrorMessage";
-import * as S from "./styles";
 import formInputsValidation from "./validations";
+import * as S from "./styles";
 
 const LoginPage: FC = () => {
   const { t } = useTranslation("", { keyPrefix: "loginPage" });
   const [passwordShown, setPasswordShown] = useState(false);
   const [checked, setChecked] = useState(false);
-  const { signin, user, error } = useAuth();
+  const { signin, user, loginError, setLoginError } = useAuth();
+
+  useLayoutEffect(() => {
+    setLoginError(undefined);
+  }, []);
 
   const handleCheckboxChange = () => {
     setChecked(!checked);
@@ -37,7 +41,7 @@ const LoginPage: FC = () => {
         <S.H4>{t("loginHeader")}</S.H4>
         <S.InfoText>{t("loginSubtitle")}</S.InfoText>
         <S.StyledLink to="/">{t("learnMore")}</S.StyledLink>
-        {error && (
+        {loginError && (
           <S.LoginErrorMessage>{t("loginErrorMessage")}</S.LoginErrorMessage>
         )}
         <Form


### PR DESCRIPTION
Fix following bug in LoginPage by updating context.

When user types email and password that pass validation but are not mocked in database, the notification about wrong email or password appears. When they go to e.q. main page and then return to Moderator page the email and password inputs has been refreshed, but the notification stays.